### PR TITLE
fix for head and tail port

### DIFF
--- a/graphviz2drawio/mx/EdgeFactory.py
+++ b/graphviz2drawio/mx/EdgeFactory.py
@@ -11,6 +11,14 @@ class EdgeFactory:
     def from_svg(self, g):
         gid = SVG.get_title(g).replace("--", "->")
         fr, to = gid.split("->")
+        gid_template = "{}->{}"
+        sp_fr = fr.split(":")
+        sp_to = to.split(":")
+        if len(sp_fr) == 2:
+            fr = sp_fr[0]
+        if len(sp_to) == 2:
+            to = sp_to[0]
+        gid = gid_template.format(fr, to)
         curve = None
         if SVG.has(g, "path"):
             path = SVG.get_first(g, "path")

--- a/test/directed/port.gv.txt
+++ b/test/directed/port.gv.txt
@@ -1,0 +1,6 @@
+digraph graph_name {
+  a1 a2;
+  b1;
+  a1 -> b1[headport=w; tailport=e];
+  a1 -> b2
+}

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -62,6 +62,14 @@ def test_hello():
     check_edge_dir(edge, dx=0, dy=1)
 
 
+def test_port():
+    file = "./directed/port.gv.txt"
+    xml = graphviz2drawio.convert(file)
+    root = ET.fromstring(xml)
+    elements = check_xml_top(root)
+    check_edge(elements[2], elements[4], elements[5])
+
+
 def test_polylines():
     file = "./undirected/polylines.gv.txt"
     xml = graphviz2drawio.convert(file)


### PR DESCRIPTION
I got error when I write edge with headport and tailport option.
The error caused by pygraphviz.
When pygraphviz creates svg file from dot file with headport and tailport option, the title becomes
"source:tailport->target:headport" and EdgeFactory looks it as key of edge dict.