### PR TITLE
update packaging metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     license="GPLv3",
     keywords="graphviz graph agraph dot convert conversion draw drawio mxgraph xml",
     packages=find_packages(exclude=["contrib", "docs", "tests"]),
+    python_requires=">=3.5",
     install_requires=["pygraphviz", "raven", "svg.path"],
     tests_require=["pytest"],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -47,4 +47,5 @@ setup(
         "Bug Reports": "https://github.com/hbmartin/graphviz2drawio/issues",
         "Source": "https://github.com/hbmartin/graphviz2drawio/",
     },
+    include_package_data=True,
 )


### PR DESCRIPTION
Thanks for this tool!

This PR updates `setup.py` to:
- more formally specify the python it requires via `python_requires`
- ensure the `LICENSE.md` is included in the distributions (not present in at least `0.2.0.tar.gz`) via `include_package_data`
  - `setuptools` (or whoever's responsible) knows about `LICENSE(.txt)`, but not `.md`