### PR TITLE
Typo leads to  error: UnboundLocalError: local variable 'cb' referenced before assignment.

### DIFF
--- a/graphviz2drawio/mx/MxGraph.py
+++ b/graphviz2drawio/mx/MxGraph.py
@@ -114,8 +114,8 @@ class MxGraph:
             array = ET.SubElement(geo, MxConst.ARRAY, {"as": "points"})
         for cb in curve.cbset:
             ET.SubElement(array, MxConst.POINT, x=str(cb[0][0]), y=str(cb[0][1]))
-        if cb:
-            ET.SubElement(array, MxConst.POINT, x=str(cb[1][0]), y=str(cb[1][1]))
+            if cb:
+                ET.SubElement(array, MxConst.POINT, x=str(cb[1][0]), y=str(cb[1][1]))
 
         # TODO: needs to account for multiple bezier in path
         # array = ET.SubElement(geo, MxConst.ARRAY, {"as": "points"})


### PR DESCRIPTION
Thanks for this project!
There was an indenting typo leading to an error: UnboundLocalError: local variable 'cb' referenced before assignment.
Could you merge and push to pipy otherwise I can't use the current verison?