### PR TITLE
Simplify image node style, add deepwiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/graphviz2drawio/badges/version.svg)](https://anaconda.org/conda-forge/graphviz2drawio)
 [![homebrew version](https://img.shields.io/homebrew/v/graphviz2drawio)](https://formulae.brew.sh/formula/graphviz2drawio)
 [![Lint and Test](https://github.com/hbmartin/graphviz2drawio/actions/workflows/lint.yml/badge.svg)](https://github.com/hbmartin/graphviz2drawio/actions/workflows/lint.yml)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hbmartin/graphviz2drawio)
 [![CodeFactor](https://www.codefactor.io/repository/github/hbmartin/graphviz2drawio/badge)](https://www.codefactor.io/repository/github/hbmartin/graphviz2drawio)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=hbmartin_graphviz2drawio&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=hbmartin_graphviz2drawio)
 
@@ -89,7 +89,9 @@ where `graph_to_convert` can be any of a file path, file handle, string of dot l
 
 Pull requests and issue reports are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
-Thanks to all the people who have contributed to this project.
+To see architectural and process diagrams please visit [the deepwiki page](https://deepwiki.com/hbmartin/graphviz2drawio)
+
+Thanks to all the people who have contributed to this project!
 
 [![Profile images of all the contributors](https://contrib.rocks/image?repo=hbmartin/graphviz2drawio)](https://github.com/hbmartin/graphviz2drawio/graphs/contributors)
 
@@ -98,8 +100,8 @@ Thanks to all the people who have contributed to this project.
 ```bash
 git clone git@github.com:hbmartin/graphviz2drawio.git
 cd graphviz2drawio
-python3 -m venv venv
-source venv/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 # Replace with the actual path to your dot files
 python -m graphviz2drawio test/directed/hello.gv.txt

--- a/graphviz2drawio/mx/Styles.py
+++ b/graphviz2drawio/mx/Styles.py
@@ -82,7 +82,7 @@ class Styles(Enum):
     LARROW = "flipH=1;" + RARROW
     IMAGE = (
         "shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;"
-        "imageAspect=0;image={image};"
+        "imageAspect=0;image={image};" + NODE
     )
 
     @staticmethod

--- a/graphviz2drawio/mx/Styles.py
+++ b/graphviz2drawio/mx/Styles.py
@@ -82,7 +82,7 @@ class Styles(Enum):
     LARROW = "flipH=1;" + RARROW
     IMAGE = (
         "shape=image;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;aspect=fixed;"
-        "imageAspect=0;image={image};" + NODE
+        "imageAspect=0;image={image};"
     )
 
     @staticmethod

--- a/test/test_bezier.py
+++ b/test/test_bezier.py
@@ -23,7 +23,7 @@ class TestApproximateCubicBezierAsQuadratic(unittest.TestCase):
         self.assertEqual(result[0], p0)
         self.assertEqual(result[2], p2)
         # Control point should be somewhere reasonable
-        self.assertTrue(isinstance(result[1], complex))
+        self.assertIsInstance(result[1], complex)
 
     def test_straight_line_approximation(self):
         """Test approximation of a cubic curve that's essentially a straight line."""
@@ -165,8 +165,7 @@ class TestSubdivideInflections(unittest.TestCase):
 
         result = subdivide_inflections(p0, c1, c2, p3)
 
-        # Should have at least one subdivision
-        self.assertTrue(len(result) >= 2)
+        self.assertEqual(len(result), 2)
 
         # All curves should connect properly
         for i in range(len(result) - 1):


### PR DESCRIPTION
## Summary by Sourcery

Improve project documentation, streamline image styling logic, and strengthen Bezier curve tests

Enhancements:
- Simplify the IMAGE node style by removing redundant NODE concatenation

Documentation:
- Add an DeepWiki badge to the README and link to the DeepWiki page for architectural diagrams
- Update the README’s Python setup instructions to use a `.venv` directory

Tests:
- Replace `assertTrue(isinstance(...))` with `assertIsInstance` in Bezier tests
- Tighten the inflection subdivision test to expect exactly two segments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to feature an "Ask DeepWiki" badge and link to project diagrams on DeepWiki.
  - Adjusted instructions for setting up the Python virtual environment.
  - Minor wording improvement in the contributors' acknowledgment.

- **Style**
  - Refined test assertions for improved clarity and specificity.

- **Refactor**
  - Updated style definitions to simplify image styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplify image node style, update README with DeepWiki link, and improve Bezier curve tests.
> 
>   - **Documentation**:
>     - Add "Ask DeepWiki" badge and link to DeepWiki in `README.md`.
>     - Update Python virtual environment setup instructions in `README.md`.
>   - **Tests**:
>     - Replace `assertTrue(isinstance(...))` with `assertIsInstance` in `test_simple_curve_approximation()` in `test/test_bezier.py`.
>     - Change inflection subdivision test in `test_complex_s_curve()` to expect exactly two segments in `test/test_bezier.py`.
>   - **Style**:
>     - Simplify image node style by removing redundant NODE concatenation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hbmartin%2Fgraphviz2drawio&utm_source=github&utm_medium=referral)<sup> for 042d0696df02873162341363aa4b5a90a9152a02. You can [customize](https://app.ellipsis.dev/hbmartin/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->