### PR TITLE
Fixes for Dockerfile and related scripts and workflows

### DIFF
--- a/.github/workflows/regenerate_linux_specs.yml
+++ b/.github/workflows/regenerate_linux_specs.yml
@@ -26,16 +26,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Regenerate Linux specs
-        run: docker run --rm -v "$PWD:/work" -w /work graphviz2drawio-spec-env ./scripts/generate_specs.sh test/ specs/linux/
-      - name: Fix generated file ownership
-        run: sudo chown -R "$USER":"$USER" specs/linux
+        run: docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work graphviz2drawio-spec-env ./scripts/generate_specs.sh test/ specs/linux/
       - name: Create pull request if specs changed
         env:
           BASE_BRANCH: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}
           PR_BRANCH: automation/regenerate-linux-specs-${{ github.run_id }}
         run: |
-          if git diff --quiet -- specs/linux; then
+          git add specs/linux
+          if git diff --cached --quiet -- specs/linux; then
             echo "No Linux spec changes found."
             exit 0
           fi

--- a/.github/workflows/spec_test.yml
+++ b/.github/workflows/spec_test.yml
@@ -21,4 +21,4 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Run spec tests
-        run: docker run --rm -v "$PWD:/work" -w /work graphviz2drawio-spec-env ./scripts/test_specs.sh test/ tmp_out/
+        run: docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work graphviz2drawio-spec-env ./scripts/test_specs.sh test/ tmp_out/

--- a/generate_specs.sh
+++ b/generate_specs.sh
@@ -41,11 +41,11 @@ done < <(find "$specs_dir" -type f -name "*.xml" -print0)
 
 if [ "$specs_found" = false ]; then
     # Bootstrap an empty specs directory by processing every source graph.
-    find "$source_dir" -type f -name "*.gv.txt" -print0 | while IFS= read -r -d "" file; do
+    while IFS= read -r -d "" file; do
         rel_path="${file#$source_dir/}"
         output_file="$specs_dir/${rel_path%.gv.txt}.xml"
         generate_spec "$file" "$output_file"
-    done
+    done < <(find "$source_dir" -type f -name "*.gv.txt" -print0)
 fi
 
 echo "All spec files have been processed."

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -39,3 +39,10 @@ COPY pyproject.toml uv.lock ./
 
 RUN uv python install 3.12 \
     && uv sync --locked --no-install-project
+
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin spec-runner \
+    && chown spec-runner:spec-runner /work
+
+ENV HOME=/tmp
+
+USER spec-runner

--- a/scripts/spec_env.sh
+++ b/scripts/spec_env.sh
@@ -7,5 +7,5 @@ image="graphviz2drawio-spec-env"
 
 docker build --platform linux/amd64 -t "$image" -f "$repo_root/scripts/Dockerfile" "$repo_root"
 
-# Linux hosts may see root-owned files in bind-mounted output directories.
-exec docker run --rm --platform linux/amd64 -v "$repo_root:/work" -w /work "$image" "$@"
+# Match the host UID/GID so bind-mounted output files stay writable locally.
+exec docker run --rm --platform linux/amd64 --user "$(id -u):$(id -g)" -v "$repo_root:/work" -w /work "$image" "$@"

--- a/test_specs.sh
+++ b/test_specs.sh
@@ -70,7 +70,7 @@ process_files() {
     local out_dir="$2"
     local expected_dir="$3"
 
-    find "$expected_dir" -type f -name "*.xml" -print0 | while IFS= read -r -d "" file; do
+    while IFS= read -r -d "" file; do
         rel_path="${file#$expected_dir/}"
         source_file="$src_dir/${rel_path%.xml}.gv.txt"
         output_file="$out_dir/$rel_path"
@@ -86,7 +86,7 @@ process_files() {
             return 1
         fi
         echo "Processed: $source_file -> $output_file"
-    done
+    done < <(find "$expected_dir" -type f -name "*.xml" -print0)
 }
 
 # Function to compare files ignoring unstable IDs


### PR DESCRIPTION
stage specs/linux first, then check git diff --cached --quiet. fixed test_specs.sh and generate_specs.sh so both piped find | while loops now use process substitution, now failures propagate correctly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/graphviz2drawio/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Dockerfile and CI workflows to run spec containers as non-root with host UID/GID
> - Adds a non-root `spec-runner` user (UID 10001) to [scripts/Dockerfile](https://github.com/hbmartin/graphviz2drawio/pull/134/files#diff-4dbf6ef68499f08024343bd94b202b3d2218a54d599dd8572820e0da1a62150b), sets `/work` ownership, and sets `HOME=/tmp` so containers default to non-root.
> - Passes `--user "$(id -u):$(id -g)"` in [scripts/spec_env.sh](https://github.com/hbmartin/graphviz2drawio/pull/134/files#diff-54f9e3c16001f2e502e8cf046795f18b0ab2e9d544df1b9f949c0712ace3f1de) and both CI workflows so bind-mounted outputs are owned by the host user.
> - Removes the post-run `chown` step from the `regenerate_linux_specs` workflow now that the container runs with the correct UID.
> - Fixes staged-change detection in the PR creation script to use `git add specs/linux` + `git diff --cached --quiet` instead of checking the working tree.
> - Replaces piped `find ... -print0 | while read -d ''` with process-substitution loops in [generate_specs.sh](https://github.com/hbmartin/graphviz2drawio/pull/134/files#diff-e3b90a4b2d577858126bec5ed2d871021fb6aa8dd0fc78e753dd46219a5f001b) and [test_specs.sh](https://github.com/hbmartin/graphviz2drawio/pull/134/files#diff-92907a071f26fb2d37b7ac0cb4d17687300043ed44dbb897671a9270091a71fb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d16fcd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->