### PR TITLE
macOS pygraphviz build fix — added after the uv sync block: explains …

### DIFF
--- a/.claude/skills/compare-render/SKILL.md
+++ b/.claude/skills/compare-render/SKILL.md
@@ -75,7 +75,7 @@ targeted comparison passes:
   committed expected XML in `specs/` (ignoring unstable ids):
 
   ```bash
-  ./scripts/test_specs.sh test tmp_out
+  uv run ./scripts/test_specs.sh test tmp_out
   ```
 
   Differences are not automatically failures — if the new output is *better*,

--- a/.codex/skills/compare-render/SKILL.md
+++ b/.codex/skills/compare-render/SKILL.md
@@ -69,7 +69,7 @@ Do not create bundled helper scripts for this skill. Use the repository scripts 
 When specs changed or the implementation touches shared layout, style, labels, edges, or XML generation, run the textual spec check:
 
 ```bash
-./scripts/test_specs.sh test tmp_out
+uv run ./scripts/test_specs.sh test tmp_out
 ```
 
 Treat diffs as evidence to inspect, not automatic failure. If the new output is intentionally better, update specs through the repo's normal process.

--- a/README.md
+++ b/README.md
@@ -107,16 +107,33 @@ uv sync
 uv run python -m graphviz2drawio test/directed/hello.gv.txt
 ```
 
+On macOS (Apple Silicon), `pygraphviz` compiles a C extension against Graphviz,
+and Homebrew's `/opt/homebrew` is not on the default compiler search path. If
+`uv sync` fails to build `pygraphviz` (clang error about missing
+`graphviz/cgraph.h`), install Graphviz and rebuild that package with the
+Homebrew paths:
+
+```bash
+brew install graphviz
+CFLAGS="-I$(brew --prefix graphviz)/include" \
+LDFLAGS="-L$(brew --prefix graphviz)/lib" \
+uv sync --reinstall-package pygraphviz
+```
+
 #### Spec tests
 
 Spec XMLs are stored separately for macOS and Linux because graph layout depends
 on platform font metrics. The spec test runner automatically compares against
 `specs/mac/` on macOS and `specs/linux/` on Linux.
 
+The scripts invoke `python3` directly, so run the native (macOS) variants
+through `uv run` so they resolve to the project venv. The `spec_env.sh` variants
+run inside Docker and already have the venv on `PATH`.
+
 ```bash
-./scripts/test_specs.sh test/ tmp_out/
+uv run ./scripts/test_specs.sh test/ tmp_out/
 ./scripts/spec_env.sh ./scripts/test_specs.sh test/ tmp_out/
-./scripts/generate_specs.sh test/ specs/mac/
+uv run ./scripts/generate_specs.sh test/ specs/mac/
 ./scripts/spec_env.sh ./scripts/generate_specs.sh test/ specs/linux/
 ```
 

--- a/test/undirected/transparency.gv.txt
+++ b/test/undirected/transparency.gv.txt
@@ -1,6 +1,6 @@
 graph G {
 //	graph [splines=true overlap=false]
-	graph [truecolor bgcolor="#ff00005f"]
+	graph [truecolor=true bgcolor="#ff00005f"]
 	node [style=filled fillcolor="#00ff005f"]
 	1 -- 30 [f=1];
 	1 -- 40 [f=14];


### PR DESCRIPTION
…the Apple Silicon /opt/homebrew compiler-path issue and gives the brew install graphviz + CFLAGS/LDFLAGS  uv sync --reinstall-package pygraphviz recovery commands.

Fixes transparency spec

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/graphviz2drawio/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix macOS pygraphviz build and prefix native scripts with `uv run`
> - Adds troubleshooting steps to [README.md](https://github.com/hbmartin/graphviz2drawio/pull/136/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) for building `pygraphviz` on Apple Silicon, including Homebrew installation and setting `CFLAGS`/`LDFLAGS` before re-syncing.
> - Updates example commands in the README and skill files to invoke `./scripts/test_specs.sh` and `./scripts/generate_specs.sh` via `uv run`, ensuring they resolve to the project venv.
> - Changes the `truecolor` attribute in [test/undirected/transparency.gv.txt](https://github.com/hbmartin/graphviz2drawio/pull/136/files#diff-ba44a207b54e1df80f4fb6f8f8413c0b0e55352d3360109f38d4624f0ba88f05) from bare `truecolor` to `truecolor=true` for explicit assignment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bcbdcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->