### PR TITLE
Fix URL-wrapped ellipse node detection

### DIFF
--- a/graphviz2drawio/mx/NodeFactory.py
+++ b/graphviz2drawio/mx/NodeFactory.py
@@ -61,7 +61,7 @@ class NodeFactory:
             )
             shape = (
                 Shape.ELLIPSE
-                if len(SVG.findall(g, "ellipse")) == 1
+                if len(SVG.findall_recursive(g, "ellipse")) == 1
                 else Shape.DOUBLE_CIRCLE
             )
             fill = self._extract_fill(ellipse, gradients)

--- a/test/test_node_factory.py
+++ b/test/test_node_factory.py
@@ -1,0 +1,45 @@
+from xml.etree import ElementTree
+
+from graphviz2drawio.models.CoordsTranslate import CoordsTranslate
+from graphviz2drawio.mx import Shape
+from graphviz2drawio.mx.Node import Node
+from graphviz2drawio.mx.NodeFactory import NodeFactory
+
+
+def _node_from_svg(svg: str) -> Node:
+    return NodeFactory(CoordsTranslate(0, 0)).from_svg(
+        ElementTree.fromstring(svg),
+        labelloc="c",
+        gradients={},
+    )
+
+
+def test_url_wrapped_single_ellipse_is_not_double_circle() -> None:
+    node = _node_from_svg(
+        """
+        <g xmlns="http://www.w3.org/2000/svg" id="node1" class="node">
+            <title>single</title>
+            <a href="https://example.test/single">
+                <ellipse fill="none" stroke="black" cx="32.93" cy="-40" rx="32.93" ry="18"/>
+            </a>
+        </g>
+        """,
+    )
+
+    assert node.shape == Shape.ELLIPSE
+
+
+def test_url_wrapped_double_ellipse_is_double_circle() -> None:
+    node = _node_from_svg(
+        """
+        <g xmlns="http://www.w3.org/2000/svg" id="node1" class="node">
+            <title>double</title>
+            <a href="https://example.test/double">
+                <ellipse fill="none" stroke="black" cx="32.93" cy="-40" rx="32.93" ry="18"/>
+                <ellipse fill="none" stroke="black" cx="32.93" cy="-40" rx="36.93" ry="22"/>
+            </a>
+        </g>
+        """,
+    )
+
+    assert node.shape == Shape.DOUBLE_CIRCLE


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/graphviz2drawio/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

