### PR TITLE
set project minimum to Python 3.11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Graphviz
@@ -21,11 +21,9 @@ jobs:
           enable-cache: true
       - run: uv sync --locked --dev
       - run: uv run ruff check .
-      - name: Run pytype if on 3.11, pyrefly if on 3.14, ty otherwise
+      - name: Run pyrefly if on 3.14, ty otherwise
         run: |
-          if [[ '${{ matrix.python-version }}' == 3.11* ]]; then
-            uv run --with pytype pytype -j auto graphviz2drawio
-          elif [[ '${{ matrix.python-version }}' == 3.14* ]]; then
+          if [[ '${{ matrix.python-version }}' == 3.14* ]]; then
             echo "Using pyrefly for Python 3.14"
             uv run --with pyrefly pyrefly check graphviz2drawio
           else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Create dist
       run: uv build
     - name: Publish package distributions to PyPI

--- a/.github/workflows/push_docs.yml
+++ b/.github/workflows/push_docs.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         enable-cache: true
 
     - name: Install graphviz

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ test/**/*.svg
 *.png
 triage_decisions.db
 reviews_triage/
+/tmp*

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ graphviz2drawio --encoding utf-8 yourgraph.dot
 
 ### Unsupported Python version
 
-graphviz2drawio requires **Python 3.10 or newer**. Check your interpreter with
+graphviz2drawio requires **Python 3.11 or newer**. Check your interpreter with
 `python --version`, and prefer [pipx](https://pipx.pypa.io/stable/) for the CLI
 so it runs in its own isolated, compatible environment.
 

--- a/doc/source/guides/troubleshooting.md
+++ b/doc/source/guides/troubleshooting.md
@@ -67,7 +67,7 @@ graphviz2drawio --encoding utf-8 yourgraph.dot
 
 ## Unsupported Python version
 
-graphviz2drawio requires **Python 3.10 or newer**. Check your interpreter with
+graphviz2drawio requires **Python 3.11 or newer**. Check your interpreter with
 `python --version`, and prefer [pipx](https://pipx.pypa.io/stable/) for the CLI
 so it runs in its own isolated, compatible environment.
 

--- a/graphviz2drawio/__main__.py
+++ b/graphviz2drawio/__main__.py
@@ -30,6 +30,21 @@ def _write_stderr_message(to_convert: str) -> None:
     stderr.write(f"Python: {sys.version}, g2d: {__version__}\n")
 
 
+def _add_conversion_note(
+    exc: Exception,
+    *,
+    to_convert: Path | TextIOWrapper,
+    program: str,
+    encoding: str,
+    outfile: str | None,
+) -> None:
+    output = "stdout" if outfile is None else outfile
+    exc.add_note(
+        "graphviz2drawio context: "
+        f"input={to_convert}, program={program}, encoding={encoding}, output={output}",
+    )
+
+
 def _convert_file(
     to_convert: Path | TextIOWrapper,
     program: str,
@@ -43,7 +58,7 @@ def _convert_file(
         elif isinstance(to_convert, Path):
             with to_convert.open(encoding=encoding) as contents:
                 output = convert(contents.read(), program)
-    except UnicodeDecodeError:
+    except UnicodeDecodeError as exc:
         if encoding.lower() != UTF8 and isinstance(to_convert, Path):
             # Attempt to automatically recover for file. Chinese Windows systems in
             # particular often use other encodings e.g. gbk, cp950, cp1252, etc. but
@@ -51,10 +66,24 @@ def _convert_file(
             # https://github.com/hbmartin/graphviz2drawio/issues/105
             return _convert_file(to_convert, program, UTF8, outfile)
 
+        _add_conversion_note(
+            exc,
+            to_convert=to_convert,
+            program=program,
+            encoding=encoding,
+            outfile=outfile,
+        )
         _write_stderr_message(str(to_convert))
         raise
 
-    except Exception:
+    except Exception as exc:
+        _add_conversion_note(
+            exc,
+            to_convert=to_convert,
+            program=program,
+            encoding=encoding,
+            outfile=outfile,
+        )
         _write_stderr_message(str(to_convert))
         raise
 
@@ -74,9 +103,9 @@ def _convert_file(
 
 
 def main() -> None:
-    args = Arguments(__version__).parse_args()  # pytype: disable=not-callable
+    args = Arguments(__version__).parse_args()
 
-    in_files: list[TextIOWrapper]
+    in_files: list[Path | TextIOWrapper]
     out_files: list[str | None]
 
     _validate_args(args)
@@ -91,13 +120,23 @@ def main() -> None:
         in_files = args.to_convert
         out_files = [_gv_filename_to_xml(in_file.name) for in_file in args.to_convert]
 
+    failures: list[Exception] = []
     for in_file, out_file in zip(in_files, out_files, strict=True):
-        _convert_file(
-            to_convert=in_file,
-            program=args.program,
-            encoding=args.encoding,
-            outfile=out_file,
-        )
+        try:
+            _convert_file(
+                to_convert=in_file,
+                program=args.program,
+                encoding=args.encoding,
+                outfile=out_file,
+            )
+        except Exception as exc:
+            if len(in_files) == 1:
+                raise
+            failures.append(exc)
+
+    if failures:
+        msg = f"Failed to convert {len(failures)} of {len(in_files)} files"
+        raise ExceptionGroup(msg, failures)
 
 
 def _determine_single_output(args: Namespace) -> list[str | None]:
@@ -125,7 +164,7 @@ def _validate_args(args: Namespace) -> None:
         and args.to_convert[0] == sys.stdin
         and sys.stdin.isatty()
     ):
-        Arguments(__version__).print_help()  # pytype: disable=not-callable
+        Arguments(__version__).print_help()
         sys.exit(1)
 
 

--- a/graphviz2drawio/models/SVG.py
+++ b/graphviz2drawio/models/SVG.py
@@ -26,7 +26,7 @@ def findall_recursive(g: Element, tag: str) -> list[Element]:
 
 def get_title(g: Element) -> str | None:
     if (title_el := get_first(g, "title")) is not None:
-        return title_el.text  # pytype: disable=attribute-error
+        return title_el.text
     return None
 
 

--- a/graphviz2drawio/mx/CurveFactory.py
+++ b/graphviz2drawio/mx/CurveFactory.py
@@ -57,8 +57,13 @@ class CurveFactory:
                     cubics.append(line_to_cubic(start, end))
                     linear_flags.append(True)
             elif isinstance(segment, Arc):
-                arc_cubics = [
-                    tuple(self.coords.complex_translate(point) for point in cubic)
+                arc_cubics: list[Cubic] = [
+                    (
+                        self.coords.complex_translate(cubic[0]),
+                        self.coords.complex_translate(cubic[1]),
+                        self.coords.complex_translate(cubic[2]),
+                        self.coords.complex_translate(cubic[3]),
+                    )
                     for cubic in arc_to_cubics(segment)
                 ]
                 cubics.extend(arc_cubics)

--- a/graphviz2drawio/mx/NodeFactory.py
+++ b/graphviz2drawio/mx/NodeFactory.py
@@ -57,7 +57,7 @@ class NodeFactory:
         elif (ellipse := SVG.get_first(g, "ellipse")) is not None:
             rect = rect_from_ellipse_svg(
                 coords=self.coords,
-                attrib=ellipse.attrib,  # pytype: disable=attribute-error
+                attrib=ellipse.attrib,
             )
             shape = (
                 Shape.ELLIPSE

--- a/graphviz2drawio/mx/Styles.py
+++ b/graphviz2drawio/mx/Styles.py
@@ -1,10 +1,9 @@
-from enum import Enum
+from enum import StrEnum
 
 from . import Shape
 
 
-# Make this subclass StrEnum when dropping Py 3.10 support
-class Styles(Enum):
+class Styles(StrEnum):
     NODE = (
         "verticalAlign={vertical_align};html=1;rounded=0;labelBackgroundColor=none;strokeColor={stroke};"
         "fillColor={fill};strokeWidth={stroke_width};dashed={dashed};"
@@ -96,9 +95,6 @@ class Styles(Enum):
         if dot_shape in _shape_to_style:
             return _shape_to_style[dot_shape]
         return Styles.NODE
-
-    def format(self, **values) -> str:  # noqa: ANN003
-        return self.value.format(**values)
 
 
 _shape_to_style: dict[str, "Styles"] = {

--- a/graphviz2drawio/mx/bezier.py
+++ b/graphviz2drawio/mx/bezier.py
@@ -4,7 +4,7 @@
 # See: https://github.com/fonttools/fonttools/tree/main/Lib/fontTools/cu2qu
 
 import math
-from typing import TypeAlias
+from typing import Literal, TypeAlias, overload
 
 from svg.path import Arc
 
@@ -98,8 +98,7 @@ def cubic_chain_to_quadratic_controls(
     tol = max_err / 2
     adjustment_budget = 0.75 * tol
     min_segments = [
-        2 if 0 < index < len(cubics) - 1 else 1
-        for index, _cubic in enumerate(cubics)
+        2 if 0 < index < len(cubics) - 1 else 1 for index, _cubic in enumerate(cubics)
     ]
 
     controls_by_cubic: list[list[complex]] = []
@@ -251,6 +250,26 @@ def _ellipse_derivative(
         (x * cos_rotation) - (y * sin_rotation),
         (x * sin_rotation) + (y * cos_rotation),
     )
+
+
+@overload
+def _cubic_approx_spline(
+    cubic: Cubic,
+    n: int,
+    tolerance: float,
+    *,
+    check: Literal[False],
+) -> list[complex]: ...
+
+
+@overload
+def _cubic_approx_spline(
+    cubic: Cubic,
+    n: int,
+    tolerance: float,
+    *,
+    check: bool = True,
+) -> list[complex] | None: ...
 
 
 def _cubic_approx_spline(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE.md"]
 authors = [{ name = "Harold Martin", email = "harold.martin@gmail.com" }]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 keywords = [
     "graphviz",
     "graph",
@@ -34,7 +34,6 @@ classifiers = [
     "Topic :: Multimedia :: Graphics :: Graphics Conversion",
     "Topic :: Scientific/Engineering :: Visualization",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -65,7 +64,7 @@ search_path = ["."]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
-exclude = [".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg", ".ipynb_checkpoints", ".mypy_cache", ".nox", ".pants.d", ".pyenv", ".pytest_cache", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", ".vscode", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "site-packages", "venv"]
+exclude = [".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg", ".ipynb_checkpoints", ".mypy_cache", ".nox", ".pants.d", ".pyenv", ".pytest_cache", ".ruff_cache", ".svn", ".tox", ".venv", ".vscode", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "site-packages", "venv"]
 
 # Same as Black.
 line-length = 88
@@ -73,7 +72,7 @@ indent-width = 4
 
 lint.select = ["ALL"]
 lint.ignore = ["D100", "D101", "D102", "D103", "D104", "D105", "D107", "D203", "D213", "ERA001", "ICN001", "PLR0913", "PT009", "RSE102", "S314", "SIM102", "TD002", "TID252", "N999"]
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/test/test_bezier.py
+++ b/test/test_bezier.py
@@ -182,7 +182,9 @@ def _max_deviation_for_cubic(cubic, controls: list[complex]) -> float:
     return max_deviation
 
 
-def _drawio_curved_quads(points: list[complex]) -> list[tuple[complex, complex, complex]]:
+def _drawio_curved_quads(
+    points: list[complex],
+) -> list[tuple[complex, complex, complex]]:
     quads = []
     current = points[0]
     for index in range(1, len(points) - 2):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,77 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+from graphviz2drawio import __main__ as cli
+
+
+def test_main_adds_context_note_on_single_file_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dot_file = tmp_path / "bad.dot"
+    xml_file = tmp_path / "bad.xml"
+    dot_file.write_text("digraph { bad }", encoding="utf-8")
+
+    def fail_convert(_graph: str, _program: str) -> str:
+        msg = "conversion failed"
+        raise ValueError(msg)
+
+    monkeypatch.setattr(cli, "convert", fail_convert)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["graphviz2drawio", dot_file.name])
+
+    with pytest.raises(ValueError) as exc_info:
+        cli.main()
+
+    notes = exc_info.value.__notes__
+    assert len(notes) == 1
+    assert f"input={dot_file.name}" in notes[0]
+    assert "program=dot" in notes[0]
+    assert "encoding=" in notes[0]
+    assert f"output={xml_file.name}" in notes[0]
+
+
+def test_main_converts_remaining_files_before_exception_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    good_file = tmp_path / "good.dot"
+    bad_file = tmp_path / "bad.dot"
+    worse_file = tmp_path / "worse.dot"
+    good_file.write_text("digraph { good }", encoding="utf-8")
+    bad_file.write_text("digraph { bad }", encoding="utf-8")
+    worse_file.write_text("digraph { worse }", encoding="utf-8")
+
+    def convert_or_fail(graph: str, _program: str) -> str:
+        if "good" in graph:
+            return "<mxGraphModel />"
+        msg = "conversion failed"
+        raise ValueError(msg)
+
+    monkeypatch.setattr(cli, "convert", convert_or_fail)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "graphviz2drawio",
+            good_file.name,
+            bad_file.name,
+            worse_file.name,
+        ],
+    )
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        cli.main()
+
+    assert (tmp_path / "good.xml").read_text(encoding="utf-8") == "<mxGraphModel />"
+    assert len(exc_info.value.exceptions) == 2
+    notes = [
+        note
+        for exc in exc_info.value.exceptions
+        for note in getattr(exc, "__notes__", [])
+    ]
+    assert any(f"input={bad_file.name}" in note for note in notes)
+    assert any(f"input={worse_file.name}" in note for note in notes)

--- a/test/test_drawio_render_sim.py
+++ b/test/test_drawio_render_sim.py
@@ -65,7 +65,9 @@ def _path_to_cubics(svg_path: str) -> list[Cubic]:
                 (segment.start, segment.control1, segment.control2, segment.end),
             )
         elif isinstance(segment, QuadraticBezier):
-            cubics.append(quadratic_to_cubic(segment.start, segment.control, segment.end))
+            cubics.append(
+                quadratic_to_cubic(segment.start, segment.control, segment.end),
+            )
         elif isinstance(segment, Line | Close):
             if segment.start != segment.end:
                 cubics.append(line_to_cubic(segment.start, segment.end))
@@ -85,7 +87,9 @@ def _max_deviation(cubics, points: list[complex]) -> float:
     )
 
 
-def _drawio_curved_quads(points: list[complex]) -> list[tuple[complex, complex, complex]]:
+def _drawio_curved_quads(
+    points: list[complex],
+) -> list[tuple[complex, complex, complex]]:
     quads = []
     current = points[0]
     for index in range(1, len(points) - 2):
@@ -98,24 +102,19 @@ def _drawio_curved_quads(points: list[complex]) -> list[tuple[complex, complex, 
 
 def _sample_cubics(cubics) -> list[complex]:
     return [
-        _cubic_point(cubic, sample / 80)
-        for cubic in cubics
-        for sample in range(81)
+        _cubic_point(cubic, sample / 80) for cubic in cubics for sample in range(81)
     ]
 
 
 def _sample_quads(quads) -> list[complex]:
     return [
-        _quadratic_point(*quad, sample / 80)
-        for quad in quads
-        for sample in range(81)
+        _quadratic_point(*quad, sample / 80) for quad in quads for sample in range(81)
     ]
 
 
 def _distance_to_polyline(point: complex, polyline: list[complex]) -> float:
     return min(
-        _distance_to_segment(point, start, end)
-        for start, end in pairwise(polyline)
+        _distance_to_segment(point, start, end) for start, end in pairwise(polyline)
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
     "python_full_version < '3.12'",
@@ -20,16 +20,9 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/be/84/b3f55026206a9e8820a91503308075ca48eadc515e436731ca01dbe043b3/black-26.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9942db8888e06943c5dde66ca0037dcff82a2a4ec1ad0ada9e0d2ee9d9823893", size = 1987719, upload-time = "2026-05-18T17:05:02.757Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/c6/34/7db312c5e5783d6e76cffd9d5ac8972a32badae4c6e3288dac0eed8d3bed/black-26.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:89c93167a74d3a75dfaa38a5c7cca015537d5820dd7f17d63267d674a61cae90", size = 1810083, upload-time = "2026-05-18T17:05:04.302Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/33/e2/e0101e73c2c8727634e2efcb35e2b34bd23ad70dfa673789f5773a591b21/black-26.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22f2cd76d069cc54c71f10360744ba8983fbb616903b4304a85b734915c8e1b4", size = 1860633, upload-time = "2026-05-18T17:05:06.391Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/b0/4c/e15c0c5b23cf3651035fe5addcce90e283af3548a3f91bb03d81b83106ab/black-26.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:87ed5c6f450580a2f6790bc7cbfb016dfc73bc750249762268a3695361315eef", size = 1477886, upload-time = "2026-05-18T17:05:07.96Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/9f/3f/59d43ade98d2ce5c8dc34a4e46cbecd177e6d55d7d4092969c6003ccc655/black-26.5.1-cp310-cp310-win_arm64.whl", hash = "sha256:58b4bd92cf88aacf83d88479c8f9caee044b1ec55f2451a337354a7ea2590a22", size = 1277111, upload-time = "2026-05-18T17:05:09.473Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
@@ -89,20 +82,6 @@ version = "7.14.1"
 source = { registry = "https://pkgs.safetycli.com/repository/independent-3c890/pypi/simple/" }
 sdist = { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/92/69/0d2ef01ff4b8fcecd4cba920d11e92fa4f96ae412441d3b56a90a258e69b/coverage-7.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf", size = 219722, upload-time = "2026-05-26T20:38:14.002Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/f8/ae/9afdeaa31b9d9ce98124b6abf8bb49119bf71aecae04f8567c189d91299f/coverage-7.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5274669f37f2343635a347b91a60777621341ab3378e9c6ac9335eee704bddf", size = 220240, upload-time = "2026-05-26T20:38:17.424Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/51/69/c998589871df7ea7dba865cc5ee32b5a3e1d47ba6c68ef91104c7c46fa5e/coverage-7.14.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cfe5a5fec635799ef33428f1e5e61bafa45a92a96190ba731561ba558ccc214d", size = 246981, upload-time = "2026-05-26T20:38:19.266Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/fc/10/1c7d04c13040dac531d21b712bbe08f902e6dd9b58f5d77875c4d030f8f2/coverage-7.14.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:62a9f70b52e0b5a95cfef4a5c5641b06983cadc5e538a3feeb5c00211f523ac2", size = 248812, upload-time = "2026-05-26T20:38:20.75Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/c1/65/2a38a4607ef27cadcfbcee034dba5830ae2569f90144a0f4c7dbf47d30b0/coverage-7.14.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c18ebc343e15be53049b3a2dce38fe82d58f37e20ab9094b3a39c0aa4f6bb47", size = 250675, upload-time = "2026-05-26T20:38:22.159Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/c9/a2/a446ed9752a4a59b79e0fb6cbb319f6facb2183045c0725462625e66f87e/coverage-7.14.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b84ffdf877644e7096aa936991efeed873f7f3df57b9cd001312b7668ab08550", size = 252590, upload-time = "2026-05-26T20:38:23.63Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/9e/fd/e81fbd7ba752365546e9842b1cbdaad3d6919d2a522c590aef16a281ec5e/coverage-7.14.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e854312c4103f2ad4c0dc023b69b77ebfd2c89db5f86c4c94dc2353f9a92167e", size = 247691, upload-time = "2026-05-26T20:38:25.057Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/53/35/f3c26fdaae9ea937d154ca4d372e5ea0a4167ff70d36c6074ac2eacb2f83/coverage-7.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c643734307300234fafa36bf2a040a7235f8f177ea1fd6ec1423aea6fb7b929f", size = 248716, upload-time = "2026-05-26T20:38:26.406Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/2e/14/940b6c49551fd343e8507ee2b0ba7af5d0aa04ed5bf768285cb7c72a9884/coverage-7.14.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84ac9499e48700399a5dd0ea7085b5091961fec52c68d66b4ec0d3cf7f4441b1", size = 246721, upload-time = "2026-05-26T20:38:28.282Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/aa/2c/40fc0634186c28292a662dff578866b3913983d6c375a3c2a74020938719/coverage-7.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7f02d09f70776579b926d889a4c9c235070a1f47c40458aeaca563fae5acfdb5", size = 250533, upload-time = "2026-05-26T20:38:29.753Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/de/e3/2c26bf1e811f9df991ff2a9bdddebdd13ee0665d564df7d05979f9146297/coverage-7.14.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ce66d8e46da2bb5ee313a745cbd2e391d319176c1f7a9451bfcd3a2fb920859b", size = 246990, upload-time = "2026-05-26T20:38:31.516Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/a8/b0/060260ef56bd92363ebdce0c7095ce422b06e69aae71828efeca473ab1ca/coverage-7.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c912c259304cfb5ee584481cfb7ce1ff932b4d61e6c9140b8f19cb7b5ed82332", size = 247593, upload-time = "2026-05-26T20:38:33.065Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/63/f3/501502046efeb0d6d94b5ca54941d95f1184183dd6bdb7f283985783bb4a/coverage-7.14.1-cp310-cp310-win32.whl", hash = "sha256:1238cb94638e610e972c60dac68e813f868dc7d6e982535270558443058d9d59", size = 222330, upload-time = "2026-05-26T20:38:35.36Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/a0/5d/1bf99f2c558f128faf7906817ccbdb576ba815d3b41ce2ac1719b70a3663/coverage-7.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253", size = 223261, upload-time = "2026-05-26T20:38:37.196Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/7d/d7/477ad149490e6cb849f28abea1dabb9c823cea72e7500c81b4240ce619c0/coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f", size = 219848, upload-time = "2026-05-26T20:38:38.715Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/91/82/a5eb47257c50601bb7b9a9d2857c67b7a3a85ad74180eb2c98bb1fbe0ce5/coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4", size = 220354, upload-time = "2026-05-26T20:38:40.232Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/43/8b/78419b5391a5cb706b6544390507e469d83ffc9a8248b02c4011aceb9365/coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1", size = 250771, upload-time = "2026-05-26T20:38:41.782Z" },
@@ -225,18 +204,6 @@ wheels = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.3.1"
-source = { registry = "https://pkgs.safetycli.com/repository/independent-3c890/pypi/simple/" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
-wheels = [
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
-]
-
-[[package]]
 name = "filelock"
 version = "3.29.3"
 source = { registry = "https://pkgs.safetycli.com/repository/independent-3c890/pypi/simple/" }
@@ -326,17 +293,6 @@ version = "3.0.3"
 source = { registry = "https://pkgs.safetycli.com/repository/independent-3c890/pypi/simple/" }
 sdist = { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
@@ -520,12 +476,10 @@ version = "9.0.3"
 source = { registry = "https://pkgs.safetycli.com/repository/independent-3c890/pypi/simple/" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
@@ -565,11 +519,6 @@ version = "0.4.1"
 source = { registry = "https://pkgs.safetycli.com/repository/independent-3c890/pypi/simple/" }
 sdist = { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
@@ -604,15 +553,6 @@ version = "6.0.3"
 source = { registry = "https://pkgs.safetycli.com/repository/independent-3c890/pypi/simple/" }
 sdist = { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
     { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
@@ -751,15 +691,6 @@ wheels = [
 ]
 
 [[package]]
-name = "typing-extensions"
-version = "4.15.0"
-source = { registry = "https://pkgs.safetycli.com/repository/independent-3c890/pypi/simple/" }
-sdist = { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
-wheels = [
-    { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
 name = "virtualenv"
 version = "21.4.3"
 source = { registry = "https://pkgs.safetycli.com/repository/independent-3c890/pypi/simple/" }
@@ -768,7 +699,6 @@ dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
     { name = "python-discovery" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://pkgs.safetycli.com/package/independent-3c890/pypi/packages/4b/50/7564c805bb8966d9771caaba8a143fa5e57c848ce4e7fdf2d55a1feb2ead/virtualenv-21.4.3.tar.gz", hash = "sha256:938ff0fd3f4e0f0d3a025f67a3d2f25e3c3aabbcd5857ea6170619138d72d141", size = 7644454, upload-time = "2026-06-11T16:47:04.843Z" }
 wheels = [


### PR DESCRIPTION
remove pytype
Styles now uses StrEnum
Conversion failures now get a Python 3.11 exception note with input, layout program, encoding, and output target. Multi-file CLI runs now continue converting remaining files, collect failures, and raise an ExceptionGroup summarizing failed conversions at the end.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/graphviz2drawio/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error handling with enhanced contextual messages when file conversions fail, including input, encoding, and output details.
  * Better tracking and handling when converting multiple files, with detailed information about which files failed.

* **Chores**
  * Updated minimum Python version requirement from 3.10 to 3.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->