### PR TITLE
Testing timeouts followup

### DIFF
--- a/.github/workflows/spec_test.yml
+++ b/.github/workflows/spec_test.yml
@@ -21,7 +21,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Run spec tests
-        run: docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work graphviz2drawio-spec-env ./scripts/test_specs.sh test/ tmp_out/
+        env:
+          SPEC_TEST_EXCLUDES: twopi/twopi2.xml
+        run: |
+          docker run --rm --user "$(id -u):$(id -g)" \
+            -e SPEC_TEST_EXCLUDES \
+            -v "$PWD:/work" \
+            -w /work \
+            graphviz2drawio-spec-env \
+            ./scripts/test_specs.sh test/ tmp_out/
       - name: Upload visual spec artifacts
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/README.md
+++ b/README.md
@@ -253,6 +253,15 @@ uv run ./scripts/generate_specs.sh test/ specs/mac/
 ./scripts/spec_env.sh ./scripts/generate_specs.sh test/ specs/linux/
 ```
 
+Large or slow spec fixtures can be skipped by setting `SPEC_TEST_EXCLUDES` to
+comma- or whitespace-separated paths/globs. Patterns match paths relative to the
+platform spec directory, and basenames also work for convenience.
+
+```bash
+SPEC_TEST_EXCLUDES="twopi/twopi2.xml" uv run ./scripts/test_specs.sh test/ tmp_out/
+SPEC_TEST_EXCLUDES="twopi2.xml,networkmap_*.xml" ./scripts/spec_env.sh ./scripts/test_specs.sh test/ tmp_out/
+```
+
 ## Roadmap
 * Support compatible [arrows](https://graphviz.org/docs/attr-types/arrowType/)
 * Support [multiple edges](https://graphviz.org/Gallery/directed/switch.html)

--- a/scripts/drawio_export.sh
+++ b/scripts/drawio_export.sh
@@ -140,32 +140,16 @@ render_drawio_png() {
             rm -f "$render_log"
             return 1
         fi
-        if [[ "${#timeout_cmd[@]}" -gt 0 ]]; then
-            if "${timeout_cmd[@]}" xvfb-run -a "${drawio_cmd[@]}" -x -f png -o "$output_file" "$input_file" > "$render_log" 2>&1; then
-                render_status=0
-            else
-                render_status="$?"
-            fi
+        if "${timeout_cmd[@]}" xvfb-run -a "${drawio_cmd[@]}" -x -f png -o "$output_file" "$input_file" > "$render_log" 2>&1; then
+            render_status=0
         else
-            if xvfb-run -a "${drawio_cmd[@]}" -x -f png -o "$output_file" "$input_file" > "$render_log" 2>&1; then
-                render_status=0
-            else
-                render_status="$?"
-            fi
+            render_status="$?"
         fi
     elif [[ "$xvfb_status" -eq 1 ]]; then
-        if [[ "${#timeout_cmd[@]}" -gt 0 ]]; then
-            if "${timeout_cmd[@]}" "${drawio_cmd[@]}" -x -f png -o "$output_file" "$input_file" > "$render_log" 2>&1; then
-                render_status=0
-            else
-                render_status="$?"
-            fi
+        if "${timeout_cmd[@]}" "${drawio_cmd[@]}" -x -f png -o "$output_file" "$input_file" > "$render_log" 2>&1; then
+            render_status=0
         else
-            if "${drawio_cmd[@]}" -x -f png -o "$output_file" "$input_file" > "$render_log" 2>&1; then
-                render_status=0
-            else
-                render_status="$?"
-            fi
+            render_status="$?"
         fi
     else
         rm -f "$render_log"

--- a/scripts/drawio_export.sh
+++ b/scripts/drawio_export.sh
@@ -69,11 +69,20 @@ should_disable_chromium_sandbox() {
 }
 
 render_timeout_command() {
-    case "${DRAWIO_RENDER_TIMEOUT:-300s}" in
+    local duration="${DRAWIO_RENDER_TIMEOUT:-300s}"
+    case "$duration" in
         0 | false | no)
             return 1
             ;;
     esac
+
+    # Accept only GNU timeout durations: a number with an optional decimal part
+    # and an optional s/m/h/d suffix. Anything else would make timeout exit 125
+    # and surface as an opaque "render failed", so disable the guard instead.
+    if [[ ! "$duration" =~ ^[0-9]+(\.[0-9]+)?[smhd]?$ ]]; then
+        echo "Warning: ignoring invalid DRAWIO_RENDER_TIMEOUT: $duration" >&2
+        return 1
+    fi
 
     if command -v timeout > /dev/null 2>&1; then
         command -v timeout

--- a/test_specs.sh
+++ b/test_specs.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Function to display usage information
 usage() {
     echo "Usage: $0 <source_directory> <output_directory> [mac|linux]"
+    echo "Set SPEC_TEST_EXCLUDES to comma- or whitespace-separated spec paths/globs to skip."
     exit 1
 }
 
@@ -56,6 +57,17 @@ specs_dir="$repo_root/specs/$spec_platform"
 
 source "$repo_root/scripts/drawio_export.sh"
 
+declare -a spec_exclude_patterns=()
+if [[ -n "${SPEC_TEST_EXCLUDES:-}" ]]; then
+    # Split on commas or whitespace. Patterns are matched against paths relative
+    # to specs/<platform>, and against the basename for convenience.
+    spec_excludes="${SPEC_TEST_EXCLUDES//,/ }"
+    spec_excludes="${spec_excludes//$'\n'/ }"
+    spec_excludes="${spec_excludes//$'\t'/ }"
+    read -r -a spec_exclude_patterns <<< "$spec_excludes"
+    echo "Skipping excluded spec patterns: ${spec_exclude_patterns[*]}"
+fi
+
 if [[ ! -d "$source_dir" ]]; then
     echo "Source directory does not exist: $source_dir" >&2
     exit 1
@@ -66,6 +78,20 @@ if [[ ! -d "$specs_dir" ]]; then
     exit 1
 fi
 
+is_excluded_spec() {
+    local rel_path="$1"
+    local basename="${rel_path##*/}"
+    local pattern
+
+    for pattern in "${spec_exclude_patterns[@]}"; do
+        if [[ "$rel_path" == $pattern || "$basename" == $pattern ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 # Function to process files
 process_files() {
     local src_dir="$1"
@@ -74,6 +100,11 @@ process_files() {
 
     while IFS= read -r -d "" file; do
         rel_path="${file#$expected_dir/}"
+        if is_excluded_spec "$rel_path"; then
+            echo "Skipping excluded spec: $rel_path"
+            continue
+        fi
+
         source_file="$src_dir/${rel_path%.xml}.gv.txt"
         output_file="$out_dir/$rel_path"
 
@@ -155,6 +186,10 @@ done < <(find "$output_dir" -type f -name "*.xml" -print0)
 
 while IFS= read -r -d "" file; do
     rel_path="${file#$specs_dir/}"
+    if is_excluded_spec "$rel_path"; then
+        continue
+    fi
+
     output_file="$output_dir/$rel_path"
 
     if [[ ! -f "$output_file" ]]; then


### PR DESCRIPTION
CI now skips twopi/twopi2.xml

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/graphviz2drawio/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

